### PR TITLE
allow multiple deployments for multiple sats. Update logging. More ef…

### DIFF
--- a/CPE-updater.yaml
+++ b/CPE-updater.yaml
@@ -15,6 +15,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# Note: If you are receiving a status of INVALID for a TLE file. Paste the TLE file here to see what is wrong: https://www.whatswrongwithmytle.com/
+# It is sometimes an incorrect checksum that can be fixed using this site by simply changing the last digit to the correct checksum
+# For information related to the TLE format: https://celestrak.org/NORAD/documentation/tle-fmt.php
+# For information related to the supported OEM format: https://docs.aws.amazon.com/ground-station/latest/ug/providing-custom-ephemeris-data.html
+
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Creates CPE pipeline resources 
@@ -29,6 +34,7 @@ Metadata:
           - NoradId
           - TleExpiration
           - NotificationEmail
+          - SatelliteId
 
 Parameters:
 
@@ -39,8 +45,8 @@ Parameters:
 
   SatelliteName:
     Type: String
-    Description: Name of the satellite, for which you will be updating ephemeris. 
-    Default: "JPSS-1"
+    Description: Name of the satellite, for which you will be updating ephemeris. MUST BE LOWER CASE
+    Default: "jpss-1"
 
   NoradId:
     Type: String
@@ -54,7 +60,10 @@ Parameters:
     AllowedPattern: "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$"
     ConstraintDescription: "Must be a valid email adress"
 
-
+  SatelliteId:
+    Type: String
+    Description: The UUID of the satellite as assigned by the Ground Station Service. Leave empty to automatically obtain the ID using the NORAD ID.
+    Default: ""
 
 Resources:
 
@@ -88,9 +97,14 @@ Resources:
   
   ConfigBucket:
     Type: AWS::S3::Bucket
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W35
+            reason: S3 logging is not required on this bucket as it contains only transient data
     DeletionPolicy: Delete
     Properties:
-      BucketName: !Sub '${AWS::AccountId}-config-bucket-${AWS::Region}'
+      BucketName: !Sub '${AWS::AccountId}-config-bucket-${SatelliteName}-${AWS::Region}'
       AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -114,7 +128,7 @@ Resources:
                 'aws:SecureTransport': false
             Effect: Deny
             Principal: '*'
-            Resource: !Sub 'arn:aws:s3:::${AWS::AccountId}-config-bucket-${AWS::Region}/*'
+            Resource: !Sub 'arn:aws:s3:::${AWS::AccountId}-config-bucket-${SatelliteName}-${AWS::Region}/*'
             Sid: DenyUnencryptedConnections
 
 
@@ -129,8 +143,14 @@ Resources:
 
   CpeUpdateLambda:
     Type: 'AWS::Serverless::Function'
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: Function is not required in a VPC; deploying outside a VPC simplifies deployment
     PackageType: Zip
     Properties:
+      ReservedConcurrentExecutions: 10
       Events:
         Upload:
           Type: S3
@@ -174,18 +194,33 @@ Resources:
               eventName = record['eventName']
               bucket = record['s3']['bucket']['name']
               key = record['s3']['object']['key']
-              if record['eventName'].startswith('ObjectCreated') and bucket == os.environ['BUCKET'] and key == os.environ['TLE_KEY']:
+              execution_time = record['eventTime']
 
-                daysToLive = os.environ['EXPIRATION']
+              daysToLive = os.environ['EXPIRATION']
+              satellite_id = os.environ['SATELLITE_ID']
+              norad_id = os.environ['NORAD_ID']
+              tle_key = os.environ['TLE_KEY']
+              oem_key = os.environ['OEM_KEY']
+              s3_bucket = os.environ['BUCKET']
+
+              if satellite_id == '':
+                print(f"Getting Satellite ID from NORAD ID: {norad_id}")
+                satellites = gs.list_satellites()['satellites']
+                satellite_id = next((s['satelliteId'] for s in satellites if str(s['noradSatelliteID']) == norad_id), None)
+              
+              if record['eventName'].startswith('ObjectCreated') and bucket == s3_bucket and key == tle_key:
+
+                print(f"Norad Id: {norad_id}")
+                print(f"S3 Bucket: {s3_bucket}")
+                print(f"Satellite Id: {satellite_id}")
                 print(f"Getting {key} from {bucket}")
+
                 resp = s3.get_object(Bucket=bucket, Key=key)
                 lines = list(resp['Body'].iter_lines())
-                norad_id = os.environ['NORAD_ID']
-                print(f"Norad Id: {norad_id}")
-                satellites = gs.list_satellites()['satellites']
-                print(satellites)
-                satellite_id = next((s['satelliteId'] for s in satellites if str(s['noradSatelliteID']) == norad_id), None)
-                print(f"Satellite Id: {satellite_id}")
+                # daysToLive = os.environ['EXPIRATION']
+                # satellite_id = os.environ['SATELLITE_ID']
+                # norad_id = os.environ['NORAD_ID']
+
                 start_time = datetime.utcnow() - timedelta(days=1)
                 end_time = datetime.utcnow() + timedelta(days=int(daysToLive))
                 print(f"Start: {start_time}")
@@ -199,30 +234,34 @@ Resources:
                   }
                 }], indent=2)
                 json_key = f"{key}.json"
-                print(f"Putting: {json_key}")
-                print(f"Into: {bucket}")
+                print(f"Uploading TLE data to: s3://{bucket}/{json_key}")
                 s3.put_object(
                   Bucket=bucket,
                   Key=json_key,
                   Body=tle
                 )
 
-                print("Creating Ephemeris from")
-                result = gs.create_ephemeris(
-                  name=f"{norad_id}",
-                  satelliteId=satellite_id,
-                  expirationTime=end_time,
-                  enabled=True,
-                  kmsKeyArn=os.environ['KMS_KEY'],
-                  ephemeris = {
-                    "tle": {
-                      "s3Object": {
-                        "bucket": bucket,
-                        "key": json_key
+                print(f"Creating Ephemeris from file: {tle_key}")
+                try:
+                  result = gs.create_ephemeris(
+                    name=f"{norad_id}",
+                    satelliteId=satellite_id,
+                    expirationTime=end_time,
+                    enabled=True,
+                    kmsKeyArn=os.environ['KMS_KEY'],
+                    ephemeris = {
+                      "tle": {
+                        "s3Object": {
+                          "bucket": bucket,
+                          "key": json_key
+                        }
                       }
                     }
-                  }
-                )
+                  )
+                except Exception as e:
+                  print(f"Error creating Ephemeris from file: {tle_key}. Error: {e}")
+                  return {'ephemeris_id': None}
+
                 ephem_id = result['ephemerisId']
                 print(f"Polling status for ${ephem_id}")
                 resp = gs.describe_ephemeris(ephemerisId=ephem_id)
@@ -232,25 +271,23 @@ Resources:
                   sleep(5)
                   resp = gs.describe_ephemeris(ephemerisId=ephem_id)
                   status = resp['status']
-                  print(status)
+                  print(f"Status: {status}")
 
-                print("Done polling")
+                print("Response from describe_ephemeris: ")
                 print(resp)
 
-                sendSNS(key, ephem_id, status)
+                sendSNS(key, ephem_id, status, satellite_id, execution_time)
                 
                 return {'ephemeris_id': ephem_id, status: status}
               
               
-              if record['eventName'].startswith('ObjectCreated') and bucket == os.environ['BUCKET'] and key == os.environ['OEM_KEY']:
-                
-                daysToLive = os.environ['EXPIRATION']
-                norad_id = os.environ['NORAD_ID']
+              elif record['eventName'].startswith('ObjectCreated') and bucket == s3_bucket and key == oem_key:
+
                 print(f"Norad Id: {norad_id}")
-                satellites = gs.list_satellites()['satellites']
-                print(satellites)
-                satellite_id = next((s['satelliteId'] for s in satellites if str(s['noradSatelliteID']) == norad_id), None)
+                print(f"S3 Bucket: {s3_bucket}")
                 print(f"Satellite Id: {satellite_id}")
+                print(f"Getting {key} from {bucket}")
+
                 start_time = datetime.utcnow() - timedelta(days=1)
                 end_time = datetime.utcnow() + timedelta(days=int(daysToLive))
                 print(f"Start: {start_time}")
@@ -258,22 +295,27 @@ Resources:
                 
                 key = urllib.parse.unquote_plus(event['Records'][0]['s3']['object']['key'], encoding='utf-8')
               
-                result = gs.create_ephemeris(
-                  name='Norad Id',
-                  satelliteId=satellite_id,
-                  enabled=True,
-                  expirationTime=end_time,
-                  kmsKeyArn=os.environ['KMS_KEY'],
-                  ephemeris = {
-                      "oem":{
-                          "s3Object": {
-                              "bucket": bucket,
-                              "key": key
-                          }
-                      }
-                  }
-                )
-            
+                print(f"Creating Ephemeris from file: {oem_key}")
+                try:
+                  result = gs.create_ephemeris(
+                    name='Norad Id',
+                    satelliteId=satellite_id,
+                    enabled=True,
+                    expirationTime=end_time,
+                    kmsKeyArn=os.environ['KMS_KEY'],
+                    ephemeris = {
+                        "oem":{
+                            "s3Object": {
+                                "bucket": bucket,
+                                "key": key
+                            }
+                        }
+                    }
+                  )
+                except Exception as e:
+                  print(f"Error creating Ephemeris from file: {oem_key}. Error: {e}")
+                  return {'ephemeris_id': None}
+
                 ephem_id = result['ephemerisId']
                 print(f"Polling status for ${ephem_id}")
                 resp = gs.describe_ephemeris(ephemerisId=ephem_id)
@@ -288,25 +330,29 @@ Resources:
                 print("Done polling")
                 print(resp)
                 
-                sendSNS(key, ephem_id, status)
+                sendSNS(key, ephem_id, status, satellite_id, execution_time)
                 
                 return {'ephemeris_id': ephem_id, status: status}
+              
+              else:
+                print(f"Key: {key} is not the name of an ephemeris file processed by this function")
 
               return {'ephemeris_id': None}
 
-          def sendSNS(key, ephem_id, status):
+          def sendSNS(key, ephem_id, status, satellite_id, execution_time):
               # SNS message
               print("Sending SNS notification.")
               snsclient = boto3.client('sns', region_name = os.environ.get("AWS_REGION"))
               now = datetime.now(timezone.utc).strftime("%I:%M%p %B %d, %Y")
-              FileName = "For the CPE file " + key
-              DateTime = " uploaded on " + now
-              EphemerisID = " the Ephemeris ID is " + ephem_id
-              EphemerisStatus = " and the status is " + status
+              Txt1 = "Finished Processing file " + key + " for satellite: " + satellite_id
+              Txt2 = ".     File uploaded on " + execution_time
+              Txt3 = ".     Processing completed on " + now
+              Txt4 = ".     The Ephemeris ID is " + ephem_id
+              Txt5 = " and the status is " + status
               
               response = snsclient.publish(
                   TargetArn=os.environ.get("SNS_TOPIC"),
-                  Message= FileName + DateTime + EphemerisID + EphemerisStatus,
+                  Message= Txt1 + Txt2 + Txt3 + Txt4 + Txt5,
                   Subject='Ground Station CPE Status',
               )
 
@@ -315,11 +361,12 @@ Resources:
         Variables:
           TLE_KEY: !Sub 'configs/${SatelliteName}-tle.txt'
           OEM_KEY: !Sub 'configs/${SatelliteName}.oem'
-          BUCKET: !Sub '${AWS::AccountId}-config-bucket-${AWS::Region}'
+          BUCKET: !Sub '${AWS::AccountId}-config-bucket-${SatelliteName}-${AWS::Region}'
           NORAD_ID: !Ref NoradId
           EXPIRATION: !Ref TleExpiration
           KMS_KEY: !GetAtt Key.Arn
           SNS_TOPIC: !Ref SNSTopic
+          SATELLITE_ID: !Ref SatelliteId
       Policies:
         - AWSLambdaExecute
         - Version: '2012-10-17'
@@ -340,7 +387,7 @@ Resources:
               Action:
                 - 's3:GetObject'
                 - 's3:PutObject'
-              Resource: !Sub 'arn:aws:s3:::${AWS::AccountId}-config-bucket-${AWS::Region}/*'
+              Resource: !Sub 'arn:aws:s3:::${AWS::AccountId}-config-bucket-${SatelliteName}-${AWS::Region}/*'
             - Effect: Allow
               Action:
                 - 'kms:Encrypt'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This guide deploys a pipeline that uses AWS Ground Station Customer Provided Eph
 CPE allows customers to provide their own orbital parameters, rather than AWS Ground Station obtaining the information automatically, 
 this is especially useful during LEOP when ephemeris data is not yet available from NORAD and for craft that are not tracked by NORAD. 
 
-There is also an option section at the end of this document on deploying a lambda function, which will automatically reschedule any contacts 6 days into the future for the satellite to ensure the updated orbital parameters are used.
+There is also an option section at the end of this document to deploy a lambda function, which will automatically reschedule any contacts several days into the future for the satellite to ensure the updated orbital parameters are used.
 
 Please refer to the [AWS Ground Station API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/groundstation.html) guide for additional information on how the CPE API works.
 
@@ -14,7 +14,7 @@ Please refer to the [AWS Ground Station API](https://boto3.amazonaws.com/v1/docu
 
 ## Pre-requisites
 
-This guide use the JPSS-1 craft as an example, so you must have it on boarded into your AWS account. Alternatively, you can use your own craft by setting the "SatelliteName" parameter in the CloudFormation template to your craft name. 
+This guide uses the JPSS-1 craft as an example, so you must have that satellite on-boarded into your AWS account. Alternatively, you can use your own craft by setting the "SatelliteName" parameter in the CloudFormation template to your craft name. 
 
 To get JPSS-1 onboarded to your account for the CPE public beta send an email to aws-groundstation@amazon.com with the following details:
 - Satellite NORAD ID: 43013 (JPSS-1)
@@ -33,28 +33,29 @@ Enter parameters as follows in the CloudFormation console and then deploy the st
 - NoradId: NoradId of the satellite, for which you will be updating ephemeris.  ("43013" for this example)
 - TleExpiration: Number of days that the ephemeris will be valid.  (Keep the default for this example)
 - NotificationEmail: Email address to receive ephemeris update status.
+- SatelliteId: (Optional) The satellite-id (use `aws groundstation list-satellites` to obtain the satellite ID)
 
+Note, if the SatelliteId parameter is left blank the NORAD ID will be used.
 
 ## Updating TLEs for a satellite
 
-Create a file named `some_satellite-tle.txt` (replacing `some_satellite` with your satellite name). 
+1. Create a file named `SatelliteName-tle.txt` (replacing `SatelliteName` with the value used for the `SatelliteName` CloudFormation parameter).
 
-Using JPSS-1 as an example:
-1. Use the command below to push the latest JPSS-1 TLE data into a file named JPSS-1-tle.txt
+If you are using JPSS-1 the command below will obtain the latest JPSS-1 TLE data from Celestrak into a file named JPSS-1-tle.txt
 
 ```bash
 curl https://celestrak.org/NORAD/elements/gp.php\?CATNR\=43013 -o JPSS-1-tle.txt
 ```
 
-2. Get the name of the S3 bucket bucket, where you need to upload the TLE file from the Outputs section of the CloudFormation template that you deployed. It should have the following format: `<AWS-account-ID>-config-bucket-<aws-region>`. 
+2. Get the name of the S3 bucket, where you need to upload the TLE file from the Outputs section of the CloudFormation template that you deployed. It will have the following format: `<AWS-account-ID>-config-bucket-<SatelliteName>-<aws-region>`. 
 
-3. Create a folder names `configs` in the above S3 bucket and upload the `JPSS-1-tle.txt` file there. The file should be uploaded to `/configs/JPSS-1-tle.txt`. This triggers a lambda function that uses the CPE API to update the ephemeris for the selected craft.
+3. Create a folder named `configs` in the above S3 bucket and upload the `SatelliteName-tle.txt` file there. The file should be uploaded to `/configs/SatelliteName-tle.txt`. Uploading the file to S3 triggers a lambda function that uses the CPE API to update the ephemeris for the selected satellite.
 
-4. Check your email for the CPE status change notification. 
+4. Once the Lambda function has finished, you should receive an email containing the result of CPE status change.
 
 5. Confirm the TLE update was successful by following the steps below:
 
-- Check the S3 bucket for the object `/configs/JPSS-1-tle.txt.json`. It should look similar to the file below.
+- Check the S3 bucket for the object `/configs/SatelliteName-tle.txt.json`. It should look similar to the file below.
 
 ```json
 [
@@ -78,6 +79,7 @@ curl https://celestrak.org/NORAD/elements/gp.php\?CATNR\=43013 -o JPSS-1-tle.txt
         TRAJECTORY_INVALID - Provided ephemeris defines an invalid spacecraft trajectory
 
         VALIDATION_ERROR - Internal service error occurred while processing ephemeris for validation
+
 
 
 ## Updating OEMs for a satellite
@@ -107,7 +109,52 @@ Using JPSS-1 as an example:
 6. Confirm the OEM update was successful by checking that the CPE Update Lambda function `<CFN-stack-name>-CpeUpdateLambda-<randomstring>` ran OK. The easiest way is to check CloudWatch logs (the log group will be named the same as the Lambda function). You should see `VALIDATING`, then `ENABLED` to indicate that the OEM file was valid and successfully updated for the specified satellite. If you see `VALIDATING`, then `INVALID`, the OEM file was incorrect for some reason. Check the section above on TLE updates for more information for the `INVALID` status. 
 
 
+## Obtaining the Ephemeris in-use by a satellite
 
+The active Ephemeris used by a satellite can be obtained using the AWS CLI.
+The process below obtains the TLE in used by a satellite.
+
+1. List all the satellites for this AWS account in a required AWS region:
+
+`aws groundstation list-satellites --region <aws-region>`
+
+2. Copy the satellite-id from the previous command and use it in the next command to obtain the Ephemeris id for the satellite:
+
+`aws groundstation get-satellite --satellite-id <satellite-id> --region <aws-region>`
+
+3. Copy the ephemeris-id from the previous command and use it in the next command to obtain Ephemeris info:
+
+`aws groundstation describe-ephemeris --ephemeris-id <ephemeris-id>`
+
+4. Download the ephemeris file using the (bucket and key parameters from the previous command)
+
+`aws s3 cp s3://<buckeet>/<key> .`
+
+5. Display the ephemeris info (Using the key parameter from the previous command)
+
+Windows: `type <key>`
+Linux: `cat <key>`
+
+
+## Configure AWS Ground Station to use the TLEs automaitcally provided by the AWS Ground Station Service
+
+When a satellite has been allocated a NORAD ID, the AWS Ground Station service will automatically obtain and configure the Ephemeris for a satellite, unless there is an active customer-provided emphemeris. Thus, if you would like the AWS Ground Station service to manage the Ephemeris you can either allow a customer-provided emphemeris to expire, or manually delete it.
+
+To check the expiration date of TLE data, check the `endTime` parameter in the json file obtained using the previously described `Obtaining the Ephemeris in-use by a satellite` process.
+
+To manually delete a customer-provided emphemeris use the process below:
+
+1. List all the satellites for this AWS account in a required AWS region:
+
+`aws groundstation list-satellites --region <aws-region>`
+
+2. Copy the satellite-id from the previous command and use it in the next command to obtain the Ephemeris id for the satellite:
+
+`aws groundstation get-satellite --satellite-id <satellite-id> --region <aws-region>`
+
+3. Copy the ephemeris-id from the previous command and use it in the next command to delete the customer-provided-ephemeris :
+
+`aws groundstation delete-ephemeris --ephemeris-id <ephemeris-id> --region <aws-region>`
 
 
 # Automatic contact rescheduling after ephemeris update 
@@ -134,8 +181,9 @@ Enter parameters as follows in the CloudFormation console and then deploy the st
 
 ## Auto-rescheduler post-implementation test plan
 
-1. Using the same mission profile schedule 2 contacts with the satellite, whose CPE you're updating (JPSS-1 NORAD ID: 43013) and 1 contact with another satellite (AQUA NORAD ID: 27424). 
+1. Using the same mission profile, schedule 2 contacts with the satellite, whose CPE you're updating (e.g. JPSS-1 NORAD ID: 43013) and 1 contact with another satellite (e.g. AQUA NORAD ID: 27424). 
 2. Update the ephemeris of JPSS-1 using either the TLE or OEM method. 
 3. Confirm the CpeUpdateLambda was successful (using the steps above). 
 4. Confirm the GroundStationCloudWatchEventHandlerLambda Lambda worked correctly (part of the Rescheduler CFN stack). Do this by checking its CloudWatch logs. 
 5. Check your email for an SNS notification. Only the 2 contacts scheduled with the CPE updated satellite should have been rescheduled. The other contact should **not** have been canceled and rescheduled.
+


### PR DESCRIPTION
*Description of changes:*

- Allow multiple deployments to manage multiple satellites without S3 bucket naming issues
- Add optional SatelliteId parameter - useful if you have two satellites with the same temporary NORAD ID
- Update logging - easier to read and now outputs more runtime vars for troubleshooting
- Update script execution logic to reduce runtime duration
- Update logging to make it clear when the function is called but key is not a valid file
- Update README to include SatelliteId and additional useful operational processes
- Update email text with more info